### PR TITLE
Fix build and update `Cargo.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,10 +5,10 @@ target = "valida-unknown-baremetal-gnu"
 linker = "/valida-toolchain/bin/ld.lld"
 rustflags = [
     "-C", "link-arg=/valida-toolchain/ValidaEntryPoint.o",
+    "-C", "link-arg=/valida-toolchain/io.o",
     "-C", "link-arg=--script=/valida-toolchain/valida.ld",
     "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libc.a",
     "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libm.a",
-    "-C", "link-arg=--noinhibit-exec",
 ]
 
 [env]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,3 @@
 name = "fibonacci"
 version = "0.1.0"
 edition = "2021"
-
-[dependencies]
-valida-rs = { git = "https://github.com/lita-xyz/valida-rs.git", branch = "no-deps" }


### PR DESCRIPTION
With https://github.com/lita-xyz/valida-toolchain/pull/709 this only works with the updated config. Also, now that we have `stdio` `read` we don't need `valida-rs` anymore.